### PR TITLE
get cosa back to throwing a specialized validation error

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -8,7 +8,7 @@ const clone = require('clone');
 const EJSON = require('mongodb-extended-json');
 const Cursor = require('./cursor');
 const errors = require('./errors');
-const { pathEq, complement, pathOr } = require('omnibelt');
+const { pathEq, complement, pathOr, pick } = require('omnibelt');
 
 const { buildPropertySchema } = require('./utils');
 
@@ -20,6 +20,14 @@ Immutable.use('objectid', require('./bson-objectId'));
 Immutable.use(require('./object'));
 
 const isNotVirtual = complement(pathEq([ 'type' ], 'virtual'));
+const onlyJoiOptions = pick(['abortEarly', 'convert', 'allowUnknown', 'skipFunctions', 'stripUnknown']);
+const defaultJoiOptions = {
+  abortEarly: false,
+  convert: false,
+  allowUnknown: false,
+  skipFunctions: true,
+  stripUnknown: false
+};
 
 const db = require('./db');
 // functions that are defined later on.
@@ -215,18 +223,13 @@ const _create = (data, definition) => {
     return this._validate(this.toObject(), options);
   };
 
-  definition.methods._validate = function(obj, options) {
-    const { abortEarly, convert, allowUnknown, skipFunctions, stripUnknown } = defaults(
-      options,
-      {
-        abortEarly: false,
-        convert: false,
-        allowUnknown: false,
-        skipFunctions: true,
-        stripUnknown: false
-      }
-    );
-    return joi.validate(obj, definition._schema, { abortEarly, convert, allowUnknown, skipFunctions, stripUnknown });
+  definition.methods._validate = async function(obj, options = {}) {
+    const joiOptions = defaults(onlyJoiOptions(options), defaultJoiOptions);
+    try {
+      return await joi.validate(obj, definition._schema, joiOptions);
+    } catch (err) {
+      throw errors.Validation(err);
+    }
   };
 
   definition.methods.save = async function(options) {

--- a/test/model.js
+++ b/test/model.js
@@ -336,9 +336,14 @@ describe('Model', () => {
 
   describe('.validate()', () => {
 
-    it('should reject promise if validation fails', () => {
+    it('should reject promise if validation fails', async () => {
       const model = FullTestModel.create({});
-      expect(model.validate()).to.be.eventually.rejectedWith({ statusCode: 400 });
+      const error = await model.validate().catch((e) => { return e; });
+      expect(error.type).to.equal('Validation');
+      expect(error.name).to.equal('ValidationError');
+      expect(error.statusCode).to.equal(400);
+      expect(error.message).to.equal('child "str" fails because ["str" is required]');
+
     });
 
     it('should resolve promise if validation succeeds', async () => {


### PR DESCRIPTION
get the validation method back to the old behavior (https://github.com/Losant/cosa/blob/2.8.2/lib/model.js#L333), and fix the test since the test was passing incorrectly.