### PR TITLE
improve model instance creation time

### DIFF
--- a/lib/defined-object.js
+++ b/lib/defined-object.js
@@ -16,7 +16,6 @@ module.exports = function (data, builder, options) {
 
   if (options.definition) {
     var definition = options.definition;
-    builder.defineProperty('__definition', Immutable.create(definition));
     if (definition.name) {
       builder.type = definition.name;
     }


### PR DESCRIPTION
I think this issue crept in with a Joi upgrade, but removing the `__definition` prop from every model instance (which is a prop we never use anyway) improves instance creation performance by about 6x.