### PR TITLE
[SP-10687] cosa del helper allow multiple properties to be passed in

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -243,11 +243,16 @@ const _create = (data, definition) => {
     });
   };
 
-  definition.methods.del = function(path) {
+  definition.methods.del = function(toDelete) {
     const original = this;
     return this.mutate(function() {
-      objectPath.del(this, path);
-      _markAsModified(this, [path], original);
+      if (!Array.isArray(toDelete)) {
+        toDelete = [toDelete];
+      }
+      toDelete.forEach((path) => {
+        objectPath.del(this, path);
+      });
+      _markAsModified(this, toDelete, original);
     });
   };
 

--- a/test/model.js
+++ b/test/model.js
@@ -183,6 +183,18 @@ describe('Model', () => {
       expect(model3.get('obj.deep.blah')).to.be.oneOf([ null, undefined ]);
     });
 
+    it('should delete multiple vars when an array is given', () => {
+      const model = FullTestModel.create({
+        str: 'foo',
+        obj: { deep: { blah: 'blah' } }
+      });
+      const model2 = model.del(['str', 'obj.deep.blah']);
+      expect(FullTestModel.isA(model2)).to.equal(true);
+      expect(model.get('str')).to.equal('foo');
+      expect(model2.get('str')).to.be.oneOf([ null, undefined ]);
+      expect(model.get('obj.deep.blah')).to.equal('blah');
+      expect(model2.get('obj.deep.blah')).to.be.oneOf([ null, undefined ]);
+    });
   });
 
   describe('.has()', () => {


### PR DESCRIPTION
SP-10687

looking at the underlying [object-path](https://www.npmjs.com/package/object-path) library we use it does look like it's possible to pass in a singular path as an array where each item represents one path level. if any such cases exist they will need to be updated in the platform code in order to keep working - i took a quick glance and i don't think we're doing that anywhere but still worth mentioning